### PR TITLE
Fix python version requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ extras_require = {
 
 
 # Require python 3.7
-if sys.version_info.major != 3 and sys.version_info.minor < 7:
+if sys.version_info < (3,7):
     sys.exit("'Pyot' requires Python >= 3.7")
 
 setup(


### PR DESCRIPTION
Fixes version requirement as != 3 will never get called unless python 2 or 4 etc is used.